### PR TITLE
patch: List compatible form-factors

### DIFF
--- a/com.github.johnfactotum.Foliate.json
+++ b/com.github.johnfactotum.Foliate.json
@@ -39,6 +39,10 @@
                     "url": "https://github.com/johnfactotum/foliate.git",
                     "tag": "2.5.0",
                     "commit": "c570ba1b03d5188aa335a485784b121f430ebcd1"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "data-List-compatible-form-factors.patch"
                 }
             ]
         }

--- a/data-List-compatible-form-factors.patch
+++ b/data-List-compatible-form-factors.patch
@@ -1,0 +1,40 @@
+From 89b116ca1144db2853c38d44eb1684e473b1eeaa Mon Sep 17 00:00:00 2001
+From: Adrien Plazas <kekun.plazas@laposte.net>
+Date: Tue, 3 Nov 2020 15:40:03 +0100
+Subject: [PATCH] data: List compatible form-factors
+
+This will allow the app to be available in Phosh and PureOS Store.
+---
+ data/com.github.johnfactotum.Foliate.appdata.xml.in | 4 ++++
+ data/com.github.johnfactotum.Foliate.desktop.in     | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/data/com.github.johnfactotum.Foliate.appdata.xml.in b/data/com.github.johnfactotum.Foliate.appdata.xml.in
+index f269661..b078380 100644
+--- a/data/com.github.johnfactotum.Foliate.appdata.xml.in
++++ b/data/com.github.johnfactotum.Foliate.appdata.xml.in
+@@ -388,4 +388,8 @@
+         </release>
+     </releases>
+     <content_rating type="oars-1.1" />
++    <custom>
++        <value key="Purism::form_factor">workstation</value>
++        <value key="Purism::form_factor">mobile</value>
++    </custom>
+ </component>
+diff --git a/data/com.github.johnfactotum.Foliate.desktop.in b/data/com.github.johnfactotum.Foliate.desktop.in
+index d73e8bf..8482b60 100644
+--- a/data/com.github.johnfactotum.Foliate.desktop.in
++++ b/data/com.github.johnfactotum.Foliate.desktop.in
+@@ -11,6 +11,8 @@ Type=Application
+ # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+ Keywords=Ebook;Book;EPUB;Viewer;Reader;
+ Actions=new-window;
++# Translators: Do NOT translate or transliterate this text (these are enum types)!
++X-Purism-FormFactor=Workstation;Mobile;
+ 
+ [Desktop Action new-window]
+ Name=Library
+-- 
+2.28.0
+


### PR DESCRIPTION
This will allow the app to be available in Phosh and PureOS Store.

The patch has been submitted upstream at https://github.com/johnfactotum/foliate/pull/621.